### PR TITLE
Spencer/eng 1288 mercury enrichment bugs

### DIFF
--- a/apis/google_books.py
+++ b/apis/google_books.py
@@ -111,10 +111,5 @@ def fetch_authors(isbn: str) -> Dict:
         authors = [enrich_author(author["url"]) for author in ol_data['data']['authors']] if 'authors' in ol_data['data'] else []
     else:
         authors = []
-
+    
     return authors
-
-def fetch_google_ol(url: str) -> Dict:
-    api_data = fetch_google(url)
-    api_data["authors"] = fetch_authors(api_data["isbn"]) if "isbn" in api_data else api_data["authors"]
-    return api_data

--- a/apis/google_books.py
+++ b/apis/google_books.py
@@ -60,7 +60,7 @@ def enrich_author(a_url: str) -> Dict:
 def fetch_amazon(url: str) -> Dict:    
     isbn = url.split("/")[-1]
     volume_url = search_isbn(isbn)
-    api_data = fetch_google_ol(volume_url)    
+    api_data = fetch_google(volume_url)    
 
     return api_data
 

--- a/apis/google_books.py
+++ b/apis/google_books.py
@@ -4,7 +4,7 @@ import json
 from typing import Dict
 import os
 from search.book import search_isbn
-from constants import google_api_url
+from constants import google_api_url, google_image_url
 
 google_key = os.getenv("GOOGLE_KEY")
 
@@ -57,22 +57,10 @@ def enrich_author(a_url: str) -> Dict:
     return author_data
 
 
-def get_google_isbn(google_id: str) -> str:    
-    isbn_data = {}
-    g_url = f'{google_api_url}/{google_id}?key={google_key}'
-    resp = requests.get(g_url)    
-    data = resp.json()["volumeInfo"]
-    
-    isbn_data["isbn10"] = data["industryIdentifiers"][0]["identifier"]
-    isbn_data["isbn13"] = data["industryIdentifiers"][1]["identifier"]
-
-    return isbn_data
-
-
 def fetch_amazon(url: str) -> Dict:    
     isbn = url.split("/")[-1]
     volume_url = search_isbn(isbn)
-    api_data = fetch_google(volume_url)    
+    api_data = fetch_google_ol(volume_url)    
 
     return api_data
 
@@ -84,46 +72,49 @@ def fetch_google(url: str) -> Dict:
     g_url = f'{google_api_url}/{gid}?key={google_key}'
     resp = requests.get(g_url)
     metadata = resp.json()    
-    data = metadata["volumeInfo"]
-
-    if "description" in data:
-        api_data["description"] = data["description"]
+    data = metadata["volumeInfo"]    
+    api_data["description"] = data["description"] if "description" in data else None
     api_data["canonicalVolumeLink"] = data["canonicalVolumeLink"]
     api_data["google_id"] = gid
-    api_data["google_url"] = data["infoLink"]
+    # api_data["google_url"] = data["infoLink"]
+    api_data["google_url"] = g_url
+    api_data["url"] = g_url
     api_data["form"] = "text"
-    api_data["image_url"] = data["imageLinks"]["extraLarge"] if "extraLarge" in data[
-        "imageLinks"] else data["imageLinks"]["large"] if "large" in data[
-            "imageLinks"] else data["imageLinks"]["medium"] if "medium" in data[
-                "imageLinks"] else data["imageLinks"]["small"] if "small" in data[
-                    "imageLinks"] else "https://ik.imagekit.io/analogue/content_placeholder_1_85wLgUnbx.jpg"
-    api_data["isbn10"] = data["industryIdentifiers"][0]["identifier"]
-    api_data["isbn13"] = data["industryIdentifiers"][1]["identifier"]
+    api_data["image_url"] = f'{google_image_url}/{gid}?fife=w400-h600&source=gbs_api' 
+    if "industryIdentifiers" in data:
+        for identifier in data["industryIdentifiers"]:
+            if identifier["type"] == "ISBN_10":
+                api_data["isbn"] = identifier["identifier"]
+            elif identifier["type"] == "ISBN_13":
+                api_data["isbn13"] = identifier["identifier"]
     api_data["language"] = data["language"]
     #api_data["medium"] = data["printType"]
     api_data["medium"] = "book"
     api_data["publisher"] = data["publisher"]
     api_data[
         "publication_date"
-    ] = data["publishedDate"].replace('-', '/')
+    ] = data["publishedDate"].replace('-', '/') if "publishedDate" in data else None
     api_data["title"] = data["title"]
     api_data["origin"] = "amazon.com"
-    api_data["origin_url"] = f"https://www.amazon.com/dp/{api_data['isbn10']}"
+    api_data["origin_url"] = f"https://www.amazon.com/dp/{api_data['isbn']}" if "isbn" in api_data else g_url
+    api_data["authors"] = [{'name': author} for author in data['authors']] if "authors" in data else []
+        
+    return api_data    
 
-    ol_url = f'http://openlibrary.org/api/volumes/brief/isbn/{api_data["isbn10"]}.json'    
+def fetch_authors(isbn: str) -> Dict:
+    ol_url = f'http://openlibrary.org/api/volumes/brief/isbn/{isbn}.json'
     ol_resp = requests.get(ol_url).json()
     if ol_resp != []:
         ol_metadata = ol_resp["records"]
         ol_key = list(ol_metadata.keys())[0]
         ol_data = ol_metadata[ol_key]
-
-        api_data["ol_work_id"] = ol_data["details"]["details"]["works"][0]["key"].split(
-            "/")[-1]
-        api_data["ol_edition_id"] = ol_data["details"]["details"]["key"].split(
-            "/")[-1]
-        api_data["authors"] = [enrich_author(author["url"]) for author in ol_data['data']['authors']] if 'authors' in ol_data['data'] else [
-            search_author(name) for name in data["authors"]]        
+        authors = [enrich_author(author["url"]) for author in ol_data['data']['authors']] if 'authors' in ol_data['data'] else []
     else:
-        api_data["authors"] = [search_author(name) for name in data["authors"]]    
+        authors = []
 
+    return authors
+
+def fetch_google_ol(url: str) -> Dict:
+    api_data = fetch_google(url)
+    api_data["authors"] = fetch_authors(api_data["isbn"]) if "isbn" in api_data else api_data["authors"]
     return api_data

--- a/app.py
+++ b/app.py
@@ -17,7 +17,7 @@ from utils.request import send_request, handle_params
 from utils.search import search
 from utils.get_twitter import get_twitter
 from utils.get_main import get_main
-from apis.google_books import get_google_isbn
+from apis.google_books import fetch_authors
 from apis.goodreads import get_goodreads_isbn
 
 sentry_key = os.getenv("SENTRY_KEY")
@@ -65,6 +65,13 @@ def enrichment():
     enriched_data = enrich(URL)
 
     return jsonify(enriched_data)
+
+@app.route("/authors")
+def authors_enrichment():
+    isbn = request.args.get("isbn")    
+    enriched_authors = fetch_authors(isbn)
+    
+    return jsonify(authors=enriched_authors)
 
 
 @app.route("/goodreads/isbn")

--- a/constants.py
+++ b/constants.py
@@ -1,4 +1,4 @@
-APIs = ["www.google.com", "www.amazon.com", "www.goodreads.com", "www.imdb.com", "open.spotify.com", "www.artsy.net", "www.wikiart.org", "en.wikipedia.org", "www.netflix.com"]
+APIs = ["www.googleapis.com", "www.amazon.com", "www.goodreads.com", "www.imdb.com", "open.spotify.com", "www.artsy.net", "www.wikiart.org", "en.wikipedia.org", "www.netflix.com"]
 fullUrlsExceptions = ['www.youtube.com']
 
 artsy_api_url = 'https://api.artsy.net/api'
@@ -27,6 +27,7 @@ netflix_url = "https://unogs-unogs-v1.p.rapidapi.com/aaapi.cgi"
 
 google_url = "https://www.google.com/search?q="
 google_api_url = "https://www.googleapis.com/books/v1/volumes"
+google_image_url = "https://books.google.com/books/publisher/content/images/frontcover"
 
 youtube_watch_url = 'https://www.youtube.com/watch?v='
 

--- a/search/book.py
+++ b/search/book.py
@@ -1,6 +1,7 @@
 import requests
 from typing import Dict
 from constants import google_api_url
+from apis import google_books
 import json
 import os
 
@@ -22,19 +23,12 @@ def search_books(query):
     resp = requests.get(api_url)
     data = resp.json()
 
-    for result in data["items"]:
-        single_result = {}
+    items = data.get("items", [])    
 
-        # Check if key exists before accessing
-        single_result["title"] = result["volumeInfo"].get("title", "Unknown Title")
-        single_result["image"] = result["volumeInfo"]["imageLinks"].get(
-            "thumbnail", None
-        )
-        single_result["creators"] = result["volumeInfo"].get("authors", [])
-        single_result["url"] = result.get("selfLink", "")
-        single_result["medium"] = "book"
+    for result in items:        
+        url = result.get("selfLink", "")
+        enriched_result = google_books.fetch_google(url)
 
-        results.append(single_result)
-        del single_result
+        results.append(enriched_result)
 
     return results

--- a/search/book.py
+++ b/search/book.py
@@ -25,9 +25,8 @@ def search_books(query):
 
     items = data.get("items", [])    
 
-    for result in items:        
-        url = result.get("selfLink", "")
-        enriched_result = google_books.fetch_google(url)
+    for result in items:                     
+        enriched_result = google_books.parse_google(result)
 
         results.append(enriched_result)
 

--- a/utils/enrichment.py
+++ b/utils/enrichment.py
@@ -4,7 +4,7 @@ from apis.spotify import spotify_get
 from apis.imdb import fetch_imdb
 from apis.goodreads import fetch_goodreads
 from apis.google_books import fetch_amazon, search_author
-from apis.google_books import fetch_google_ol
+from apis.google_books import fetch_google
 from apis.artsy import fetch_artsy
 from apis.wikiart import fetch_wikiart
 from apis.wikipedia import fetch_wikipedia
@@ -33,7 +33,7 @@ def enrich(url: str) -> Dict:
             enrich_data = fetch_amazon(url)
 
         if site_name in ("www.googleapis.com"):
-            enrich_data = fetch_google_ol(url)
+            enrich_data = fetch_google(url)
 
         if site_name in ("www.goodreads.com","goodreads.com"):
             enrich_data = fetch_goodreads(url)

--- a/utils/enrichment.py
+++ b/utils/enrichment.py
@@ -3,8 +3,8 @@ from bs4 import BeautifulSoup, SoupStrainer
 from apis.spotify import spotify_get
 from apis.imdb import fetch_imdb
 from apis.goodreads import fetch_goodreads
-from apis.google_books import fetch_amazon
-from apis.google_books import fetch_google
+from apis.google_books import fetch_amazon, search_author
+from apis.google_books import fetch_google_ol
 from apis.artsy import fetch_artsy
 from apis.wikiart import fetch_wikiart
 from apis.wikipedia import fetch_wikipedia
@@ -32,8 +32,8 @@ def enrich(url: str) -> Dict:
         if site_name in ("www.amazon.com"):
             enrich_data = fetch_amazon(url)
 
-        if site_name in ("www.google.com"):                       
-            enrich_data = fetch_google(url)
+        if site_name in ("www.googleapis.com"):
+            enrich_data = fetch_google_ol(url)
 
         if site_name in ("www.goodreads.com","goodreads.com"):
             enrich_data = fetch_goodreads(url)

--- a/utils/request.py
+++ b/utils/request.py
@@ -36,7 +36,7 @@ def send_request(param_dict: dict):
         cookie = cj.CookieJar()
         if 'twitter.com' in URL:
             return get_twitter(URL)
-        requested = requests.get(URL, headers=headers, cookies=cookie ,timeout=10)
+        requested = requests.get(URL, headers=headers, cookies=cookie, timeout=10)
 
         print(f"Status code: {requested.status_code}")
         print(f"Request Type: {type(requested)}")


### PR DESCRIPTION
- Cleaned up errors and bugs, mostly caused by inconsistent data responses from google api. Need to check existence of nearly every field before accessing
- Update constants to reflect new google api url
- Separate author enrichment logic (using open library) from main google fetching function and create endpoint just for author enrichment. The thinking behind this was to recycle the google response parsing logic when fetching external-add search results. This way, when adding from external, the data is completely enriched already, followed by a perform_later job for author enrichment. Whereas before we were hitting google's api 3 to 4 times, we're only hitting it once now.
- One thing to note, the `imageLinks` provided by google's api response are very inconsistent (even when they're present, they sometimes just render an image with "image not found" text). So, I found a hack using a static link with an item's google id.