### PR TITLE
Spencer/eng 1295 topic tags for books

### DIFF
--- a/apis/dbpedia.py
+++ b/apis/dbpedia.py
@@ -1,0 +1,72 @@
+import requests
+from bs4 import BeautifulSoup
+
+def fetch_topics(title, author):
+    db_results = fetch_db_topics(title, author)
+    ol_results = fetch_ol_topics(title, author)
+    topics = db_results + ol_results    
+    return topics
+
+def fetch_db_topics(title, author):
+    # Define the endpoint
+    endpoint = "https://lookup.dbpedia.org/api/search/KeywordSearch?QueryClass=book&MaxHits=3&QueryString="
+
+    # Construct the query URL
+    query_url = f"{endpoint}{title}"
+
+    # Fetch the data from DBpedia
+    headers = {"Accept": "application/xml"}
+    response = requests.get(query_url, headers=headers)
+
+    if response.status_code != 200:
+        print(f"Failed to fetch data from DBpedia. Status code: {response.status_code}")
+        return []
+
+    data = response.text
+
+    # Parse the XML data using BeautifulSoup
+    parsed_data = BeautifulSoup(data, 'xml')
+
+    # Fetch the first three results
+    top_results = parsed_data.find_all('Result', limit=3)
+
+    if not top_results:
+        print("No results found on DBpedia.")
+        return []
+
+    # Iterate through the results and find the first valid one
+    for result in top_results:
+        result_title = result.Label.string
+        result_description = result.Description.string if result.Description else ""
+
+        if title.lower() in result_title.lower() and author.lower() in result_description.lower():
+            # Extract categories for the valid result
+            category_uris = [category.URI.string for category in result.find_all('Category')]
+            # Extract category names from the URIs
+            category_names = [uri.split('/')[-1].replace('_', ' ').replace('Category:', '') for uri in category_uris]
+            return category_names
+
+    print(f"No exact match found on DBpedia for title: '{title}' and author: '{author}'")
+    return []
+
+def fetch_ol_topics(title, author):
+    search_url = f'https://openlibrary.org/search.json?title={title.replace(" ", "+")}&author={author.replace(" ", "+")}'
+    s_resp = requests.get(search_url).json()    
+    docs =  s_resp['docs']
+    if len(docs) > 0:
+        key = docs[0].get('key', '')        
+    else:
+        return []
+    works_url = f'https://openlibrary.org{key}.json'    
+    w_resp = requests.get(works_url).json()    
+    
+    places = w_resp.get('subject_places', [])
+    times = w_resp.get('subject_times', [])
+    people = w_resp.get('subject_people', [])
+    subjects = w_resp.get('subjects', [])
+    
+    topics = places + times + people + subjects    
+    return topics
+
+
+

--- a/apis/dbpedia.py
+++ b/apis/dbpedia.py
@@ -1,11 +1,13 @@
 import requests
 from bs4 import BeautifulSoup
 
+
 def fetch_topics(title, author):
     db_results = fetch_db_topics(title, author)
     ol_results = fetch_ol_topics(title, author)
-    topics = db_results + ol_results    
+    topics = db_results + ol_results
     return topics
+
 
 def fetch_db_topics(title, author):
     # Define the endpoint
@@ -25,10 +27,10 @@ def fetch_db_topics(title, author):
     data = response.text
 
     # Parse the XML data using BeautifulSoup
-    parsed_data = BeautifulSoup(data, 'xml')
+    parsed_data = BeautifulSoup(data, "xml")
 
     # Fetch the first three results
-    top_results = parsed_data.find_all('Result', limit=3)
+    top_results = parsed_data.find_all("Result", limit=3)
 
     if not top_results:
         print("No results found on DBpedia.")
@@ -39,34 +41,42 @@ def fetch_db_topics(title, author):
         result_title = result.Label.string
         result_description = result.Description.string if result.Description else ""
 
-        if title.lower() in result_title.lower() and author.lower() in result_description.lower():
+        if (
+            title.lower() in result_title.lower()
+            and author.lower() in result_description.lower()
+        ):
             # Extract categories for the valid result
-            category_uris = [category.URI.string for category in result.find_all('Category')]
+            category_uris = [
+                category.URI.string for category in result.find_all("Category")
+            ]
             # Extract category names from the URIs
-            category_names = [uri.split('/')[-1].replace('_', ' ').replace('Category:', '') for uri in category_uris]
+            category_names = [
+                uri.split("/")[-1].replace("_", " ").replace("Category:", "")
+                for uri in category_uris
+            ]
             return category_names
 
-    print(f"No exact match found on DBpedia for title: '{title}' and author: '{author}'")
+    print(
+        f"No exact match found on DBpedia for title: '{title}' and author: '{author}'"
+    )
     return []
+
 
 def fetch_ol_topics(title, author):
     search_url = f'https://openlibrary.org/search.json?title={title.replace(" ", "+")}&author={author.replace(" ", "+")}'
-    s_resp = requests.get(search_url).json()    
-    docs =  s_resp['docs']
+    s_resp = requests.get(search_url).json()
+    docs = s_resp["docs"]
     if len(docs) > 0:
-        key = docs[0].get('key', '')        
+        key = docs[0].get("key", "")
     else:
         return []
-    works_url = f'https://openlibrary.org{key}.json'    
-    w_resp = requests.get(works_url).json()    
-    
-    places = w_resp.get('subject_places', [])
-    times = w_resp.get('subject_times', [])
-    people = w_resp.get('subject_people', [])
-    subjects = w_resp.get('subjects', [])
-    
-    topics = places + times + people + subjects    
+    works_url = f"https://openlibrary.org{key}.json"
+    w_resp = requests.get(works_url).json()
+
+    places = w_resp.get("subject_places", [])
+    times = w_resp.get("subject_times", [])
+    people = w_resp.get("subject_people", [])
+    subjects = w_resp.get("subjects", [])
+
+    topics = places + times + people + subjects
     return topics
-
-
-

--- a/apis/google_books.py
+++ b/apis/google_books.py
@@ -1,6 +1,4 @@
-import re
 import requests
-import json
 from typing import Dict
 import os
 from search.book import search_isbn
@@ -16,23 +14,19 @@ def search_author(name: str) -> Dict:
     s_resp = requests.get(s_url)
     s_data = s_resp.json()
 
-    if s_data["numFound"] == 0:
-        author_data["name"] = name
-    else:
-        olid = s_data["docs"][0]["key"]
+    olid = s_data.get("docs", [{}])[0].get("key", None)
+    if olid:
         a_url = f'https://openlibrary.org/authors/{olid}.json'
         a_resp = requests.get(a_url)
-        a_data = a_resp.json()        
+        a_data = a_resp.json()
 
-        if "bio" in a_data:
-            author_data["about"] = a_data["bio"]
-        if "birth_date" in a_data:
-            author_data["born_at"] = a_data["birth_date"]
-        if "death_date" in a_data:
-            author_data["died_at"] = a_data["death_date"]
-        # might return Not Found
+        author_data["about"] = a_data.get("bio", None)
+        author_data["born_at"] = a_data.get("birth_date", None)
+        author_data["died_at"] = a_data.get("death_date", None)
         author_data["large_image_url"] = f"https://covers.openlibrary.org/a/olid/{olid}-L.jpg"
-        author_data["name"] = a_data["name"]
+        author_data["name"] = a_data.get("name", name)
+    else:
+        author_data["name"] = name
 
     return author_data
 
@@ -45,14 +39,12 @@ def enrich_author(a_url: str) -> Dict:
     ol_url = f'{("/").join(url_params)}.json'
     resp = requests.get(ol_url)
     data = resp.json()
-    if "bio" in data:
-        author_data["about"] = data["bio"]
-    if "birth_date" in data:
-        author_data["born_at"] = data["birth_date"]
-    if "death_date" in data:
-        author_data["died_at"] = data["death_date"]
+
+    author_data["about"] = data.get("bio", None)
+    author_data["born_at"] = data.get("birth_date", None)
+    author_data["died_at"] = data.get("death_date", None)
     author_data["large_image_url"] = f"https://covers.openlibrary.org/a/olid/{olid}-L.jpg"
-    author_data["name"] = data["name"]
+    author_data["name"] = data.get("name", None)
 
     return author_data
 
@@ -64,32 +56,34 @@ def fetch_amazon(url: str) -> Dict:
 
     return api_data
 
+
 def parse_google(result: Dict) -> Dict:    
     api_data = {}    
-    data = result["volumeInfo"]
-    api_data["description"] = data["description"] if "description" in data else None
-    api_data["canonicalVolumeLink"] = data["canonicalVolumeLink"] if "canonicalVolumeLink" in data else None
-    api_data["google_id"] = result["id"]    
-    api_data["google_url"] = data["infoLink"]
-    api_data["url"] = result["selfLink"]
+    data = result.get("volumeInfo", {})    
+
+    api_data["description"] = data.get("description", None)
+    api_data["canonicalVolumeLink"] = data.get("canonicalVolumeLink", None)
+    api_data["google_id"] = result.get("id", None)    
+    api_data["google_url"] = data.get("infoLink", None)
+    api_data["url"] = result.get("selfLink", None)
     api_data["form"] = "text"
-    api_data["image_url"] = f'{google_image_url}/{result["id"]}?fife=w400-h600&source=gbs_api' 
-    if "industryIdentifiers" in data:
-        for identifier in data["industryIdentifiers"]:
-            if identifier["type"] == "ISBN_10":
-                api_data["isbn"] = identifier["identifier"]
-            elif identifier["type"] == "ISBN_13":
-                api_data["isbn13"] = identifier["identifier"]
-    api_data["language"] = data["language"]    
+    api_data["image_url"] = f'{google_image_url}/{result.get("id", None)}?fife=w400-h600&source=gbs_api'
+    api_data["language"] = data.get("language", None)    
     api_data["medium"] = "book"
-    api_data["publisher"] = data["publisher"] if "publisher" in data else None
-    api_data[
-        "publication_date"
-    ] = data["publishedDate"].replace('-', '/') if "publishedDate" in data else None
-    api_data["title"] = data["title"]
-    api_data["origin"] = "amazon.com"
-    api_data["origin_url"] = f"https://www.amazon.com/dp/{api_data['isbn']}" if "isbn" in api_data else api_data["google_url"]
-    api_data["authors"] = [{'name': author} for author in data['authors']] if "authors" in data else []
+    api_data["publisher"] = data.get("publisher", None)
+    api_data["publication_date"] = data.get("publishedDate", "").replace('-', '/')
+    api_data["title"] = data.get("title", None)
+    api_data["origin"] = "amazon.com"        
+    api_data["authors"] = [{'name': author} for author in data.get('authors', [])]
+    api_data["topics"] = data.get("categories", [])
+
+    for identifier in data.get("industryIdentifiers", []):
+        if identifier.get("type") == "ISBN_10":
+            api_data["isbn"] = identifier.get("identifier", None)
+        elif identifier.get("type") == "ISBN_13":
+            api_data["isbn13"] = identifier.get("identifier", None)
+    
+    api_data["origin_url"] = f"https://www.amazon.com/dp/{api_data['isbn']}" if "isbn" in api_data else api_data.get("google_url", None)
 
     return api_data
 
@@ -107,11 +101,11 @@ def fetch_google(url: str) -> Dict:
 def fetch_authors(isbn: str) -> Dict:
     ol_url = f'http://openlibrary.org/api/volumes/brief/isbn/{isbn}.json'
     ol_resp = requests.get(ol_url).json()
-    if ol_resp != []:
-        ol_metadata = ol_resp["records"]
+    if ol_resp:
+        ol_metadata = ol_resp.get("records", {})
         ol_key = list(ol_metadata.keys())[0]
-        ol_data = ol_metadata[ol_key]
-        authors = [enrich_author(author["url"]) for author in ol_data['data']['authors']] if 'authors' in ol_data['data'] else []
+        ol_data = ol_metadata.get(ol_key, {})
+        authors = [enrich_author(author.get("url", "")) for author in ol_data.get('data', {}).get('authors', [])]
     else:
         authors = []
     

--- a/apis/google_books.py
+++ b/apis/google_books.py
@@ -16,14 +16,16 @@ def search_author(name: str) -> Dict:
 
     olid = s_data.get("docs", [{}])[0].get("key", None)
     if olid:
-        a_url = f'https://openlibrary.org/authors/{olid}.json'
+        a_url = f"https://openlibrary.org/authors/{olid}.json"
         a_resp = requests.get(a_url)
         a_data = a_resp.json()
 
         author_data["about"] = a_data.get("bio", None)
         author_data["born_at"] = a_data.get("birth_date", None)
         author_data["died_at"] = a_data.get("death_date", None)
-        author_data["large_image_url"] = f"https://covers.openlibrary.org/a/olid/{olid}-L.jpg"
+        author_data[
+            "large_image_url"
+        ] = f"https://covers.openlibrary.org/a/olid/{olid}-L.jpg"
         author_data["name"] = a_data.get("name", name)
     else:
         author_data["name"] = name
@@ -43,38 +45,42 @@ def enrich_author(a_url: str) -> Dict:
     author_data["about"] = data.get("bio", None)
     author_data["born_at"] = data.get("birth_date", None)
     author_data["died_at"] = data.get("death_date", None)
-    author_data["large_image_url"] = f"https://covers.openlibrary.org/a/olid/{olid}-L.jpg"
+    author_data[
+        "large_image_url"
+    ] = f"https://covers.openlibrary.org/a/olid/{olid}-L.jpg"
     author_data["name"] = data.get("name", None)
 
     return author_data
 
 
-def fetch_amazon(url: str) -> Dict:    
+def fetch_amazon(url: str) -> Dict:
     isbn = url.split("/")[-1]
     volume_url = search_isbn(isbn)
-    api_data = fetch_google(volume_url)    
+    api_data = fetch_google(volume_url)
 
     return api_data
 
 
-def parse_google(result: Dict) -> Dict:    
-    api_data = {}    
-    data = result.get("volumeInfo", {})    
+def parse_google(result: Dict) -> Dict:
+    api_data = {}
+    data = result.get("volumeInfo", {})
 
     api_data["description"] = data.get("description", None)
     api_data["canonicalVolumeLink"] = data.get("canonicalVolumeLink", None)
-    api_data["google_id"] = result.get("id", None)    
+    api_data["google_id"] = result.get("id", None)
     api_data["google_url"] = data.get("infoLink", None)
     api_data["url"] = result.get("selfLink", None)
     api_data["form"] = "text"
-    api_data["image_url"] = f'{google_image_url}/{result.get("id", None)}?fife=w400-h600&source=gbs_api'
-    api_data["language"] = data.get("language", None)    
+    api_data[
+        "image_url"
+    ] = f'{google_image_url}/{result.get("id", None)}?fife=w400-h600&source=gbs_api'
+    api_data["language"] = data.get("language", None)
     api_data["medium"] = "book"
     api_data["publisher"] = data.get("publisher", None)
-    api_data["publication_date"] = data.get("publishedDate", "").replace('-', '/')
+    api_data["publication_date"] = data.get("publishedDate", "").replace("-", "/")
     api_data["title"] = data.get("title", None)
-    api_data["origin"] = "amazon.com"        
-    api_data["authors"] = [{'name': author} for author in data.get('authors', [])]
+    api_data["origin"] = "amazon.com"
+    api_data["authors"] = [{"name": author} for author in data.get("authors", [])]
     api_data["topics"] = data.get("categories", [])
 
     for identifier in data.get("industryIdentifiers", []):
@@ -82,31 +88,38 @@ def parse_google(result: Dict) -> Dict:
             api_data["isbn"] = identifier.get("identifier", None)
         elif identifier.get("type") == "ISBN_13":
             api_data["isbn13"] = identifier.get("identifier", None)
-    
-    api_data["origin_url"] = f"https://www.amazon.com/dp/{api_data['isbn']}" if "isbn" in api_data else api_data.get("google_url", None)
+
+    api_data["origin_url"] = (
+        f"https://www.amazon.com/dp/{api_data['isbn']}"
+        if "isbn" in api_data
+        else api_data.get("google_url", None)
+    )
 
     return api_data
 
 
-def fetch_google(url: str) -> Dict:    
-    gid = url.split("/")[-1]    
-    g_url = f'{google_api_url}/{gid}?key={google_key}'
+def fetch_google(url: str) -> Dict:
+    gid = url.split("/")[-1]
+    g_url = f"{google_api_url}/{gid}?key={google_key}"
     resp = requests.get(g_url)
-    result = resp.json()    
+    result = resp.json()
     parsed_data = parse_google(result)
-    
+
     return parsed_data
-        
+
 
 def fetch_authors(isbn: str) -> Dict:
-    ol_url = f'http://openlibrary.org/api/volumes/brief/isbn/{isbn}.json'
+    ol_url = f"http://openlibrary.org/api/volumes/brief/isbn/{isbn}.json"
     ol_resp = requests.get(ol_url).json()
     if ol_resp:
         ol_metadata = ol_resp.get("records", {})
         ol_key = list(ol_metadata.keys())[0]
         ol_data = ol_metadata.get(ol_key, {})
-        authors = [enrich_author(author.get("url", "")) for author in ol_data.get('data', {}).get('authors', [])]
+        authors = [
+            enrich_author(author.get("url", ""))
+            for author in ol_data.get("data", {}).get("authors", [])
+        ]
     else:
         authors = []
-    
+
     return authors

--- a/app.py
+++ b/app.py
@@ -45,7 +45,7 @@ def Graph_data():
     all_params = dict(request.args)
     params_string = handle_params(all_params)
 
-    if 'twitter.com' in params_string:
+    if "twitter.com" in params_string:
         return get_twitter(params_string)
 
     request_object = send_request(all_params)
@@ -60,26 +60,27 @@ def Graph_data():
 
 @app.route("/enrich")
 def enrichment():
-
     URL = request.args.get("url")
 
     enriched_data = enrich(URL)
 
     return jsonify(enriched_data)
 
+
 @app.route("/authors")
 def authors_enrichment():
-    isbn = request.args.get("isbn")    
+    isbn = request.args.get("isbn")
     enriched_authors = fetch_authors(isbn)
-    
+
     return jsonify(authors=enriched_authors)
+
 
 @app.route("/topics")
 def topic_enrichment():
     title = request.args.get("title")
     author = request.args.get("author")
     enriched_topics = fetch_topics(title, author)
-    
+
     return jsonify(topics=enriched_topics)
 
 
@@ -93,12 +94,11 @@ def goodreads_isbn_endpoint():
 
 @app.route("/api/search")
 def search_endpoint():
-
     query = request.args.get("query")
     medium = request.args.get("medium")
 
     results = search(query, medium)
-    
+
     return jsonify(results)
 
 

--- a/app.py
+++ b/app.py
@@ -91,14 +91,6 @@ def goodreads_isbn_endpoint():
     return jsonify(isbn_data)
 
 
-@app.route("/google/isbn")
-def google_isbn_endpoint():
-    google_id = request.args.get("id")
-    isbn_data = get_google_isbn(google_id)
-
-    return jsonify(isbn_data)
-
-
 @app.route("/api/search")
 def search_endpoint():
 

--- a/app.py
+++ b/app.py
@@ -18,6 +18,7 @@ from utils.search import search
 from utils.get_twitter import get_twitter
 from utils.get_main import get_main
 from apis.google_books import fetch_authors
+from apis.dbpedia import fetch_topics
 from apis.goodreads import get_goodreads_isbn
 
 sentry_key = os.getenv("SENTRY_KEY")
@@ -72,6 +73,14 @@ def authors_enrichment():
     enriched_authors = fetch_authors(isbn)
     
     return jsonify(authors=enriched_authors)
+
+@app.route("/topics")
+def topic_enrichment():
+    title = request.args.get("title")
+    author = request.args.get("author")
+    enriched_topics = fetch_topics(title, author)
+    
+    return jsonify(topics=enriched_topics)
 
 
 @app.route("/goodreads/isbn")

--- a/search/book.py
+++ b/search/book.py
@@ -14,9 +14,9 @@ def search_isbn(isbn: str) -> str:
     data = resp.json()
 
     if "items" in data and len(data["items"]) > 0:
-        return data["items"][0].get("selfLink", '')
+        return data["items"][0].get("selfLink", "")
     else:
-        return ''
+        return ""
 
 
 def search_books(query):
@@ -25,9 +25,9 @@ def search_books(query):
     resp = requests.get(api_url)
     data = resp.json()
 
-    items = data.get("items", [])    
+    items = data.get("items", [])
 
-    for result in items:                     
+    for result in items:
         enriched_result = google_books.parse_google(result)
 
         results.append(enriched_result)

--- a/search/book.py
+++ b/search/book.py
@@ -12,9 +12,11 @@ def search_isbn(isbn: str) -> str:
     url = f"{google_api_url}?q=isbn:{isbn}&key={google_key}"
     resp = requests.get(url)
     data = resp.json()
-    volume_url = data["items"][0]["selfLink"]
 
-    return volume_url
+    if "items" in data and len(data["items"]) > 0:
+        return data["items"][0].get("selfLink", '')
+    else:
+        return ''
 
 
 def search_books(query):


### PR DESCRIPTION
As mentioned in Linear ticket, major development here was utilizing DBpedia, openlibrary, and google books for topic enrichment. Google's more general topic is parsed during content enrichment, while the specific (but sometimes noisy) topics from DB and OL are added during topic enrichment. I realized that fetching DB and OL data by isbn (as I had been doing before) didn't always return all the metadata for a given work (just the edition's metadata), so I search by title and author then extract the respective work ID from the search results before fetching the metadata for the correct work iD. Because OL and DB's topics can get pretty noisy (often noisier for more popular works), I do some filtering in `mercury.rb` in mainframe, but a lot more needs to be done to have super clean topics. For now, this should work for at least testing algolia's recommend model.

Overall, this strategy feels optimal as Google produces 100% topic coverage (producing a single topic), while OL and DB have lower coverage but stronger signal. Looking forward, we will likely have to utilize a python NLP package to better normalize and clean these topics. Since topic enrichment is a delayed job, we can afford to use more computationally expensive procedures like NLP without affecting UX. 